### PR TITLE
PERF: Optimize Extensions.cs

### DIFF
--- a/src/SpaInspectorReader/Extensions.cs
+++ b/src/SpaInspectorReader/Extensions.cs
@@ -14,6 +14,7 @@ public static class Extensions
 
     public static void Position(this BinaryReader binaryReader, long position) => binaryReader.BaseStream.Position = position;
 
+    private static Regex FixNewlinesRegex = new Regex(@"([^ \t\r\n])[ \t]+$", RegexOptions.Multiline | RegexOptions.Compiled);
     public static string ReadNullTerminatedString(this BinaryReader stream)
     {
         var stringBuilder = new StringBuilder();
@@ -23,7 +24,7 @@ public static class Extensions
         var str = stringBuilder.ToString();
         var fixNewlines = Regex.Replace(str, @"\r\n?", "\n");
 
-        return Regex.Replace(fixNewlines, @"([^ \t\r\n])[ \t]+$", "$1", RegexOptions.Multiline);
+        return FixNewlinesRegex.Replace(fixNewlines, "$1");
     }
 
     /// <summary>


### PR DESCRIPTION
Hi, I've tried to make some performance optimizations to this repo. Following are the benchmark results before and after the changes:

**Benchmarks before changes:**
|                     Method |          Mean |        Error |        StdDev |        Median |    Gen 0 |   Gen 1 | Allocated |
|--------------------------- |--------------:|-------------:|--------------:|--------------:|---------:|--------:|----------:|
|              SpanReadBytes |      11.41 ns |     0.275 ns |      0.786 ns |      11.25 ns |        - |       - |         - |
|             SpanReadFloats |   3,062.08 ns |   206.393 ns |    608.555 ns |   2,781.42 ns |        - |       - |         - |
|         SpanReadFloatArray |   5,269.97 ns |   175.140 ns |    493.984 ns |   5,193.01 ns |  12.9852 |       - |  27,408 B |
|        SpanReadDoubleArray |  13,912.51 ns |   339.714 ns |    969.223 ns |  13,479.62 ns |  25.6348 |       - |  54,792 B |
|             SpanReadDouble |  14,947.83 ns |   433.242 ns |  1,250.003 ns |  14,464.67 ns |  25.6348 |       - |  54,792 B |
| BinaryReaderReadAbsorbance | 232,203.99 ns | 8,963.838 ns | 23,926.299 ns | 225,189.50 ns | 105.2246 | 26.1230 | 263,256 B |


**Benchmarks after changes:**
|                     Method |          Mean |        Error |        StdDev |        Median |    Gen 0 |   Gen 1 | Allocated |
|--------------------------- |--------------:|-------------:|--------------:|--------------:|---------:|--------:|----------:|
|              SpanReadBytes |      10.21 ns |     0.144 ns |      0.160 ns |      10.18 ns |        - |       - |         - |
|             SpanReadFloats |   2,296.35 ns |    59.022 ns |    172.171 ns |   2,291.88 ns |        - |       - |         - |
|         SpanReadFloatArray |   5,058.43 ns |   241.393 ns |    700.324 ns |   4,881.85 ns |  12.9852 |       - |  27,408 B |
|             SpanReadDouble |  13,046.49 ns |   244.479 ns |    228.686 ns |  13,022.27 ns |  25.6348 |       - |  54,792 B |
|        SpanReadDoubleArray |  13,050.94 ns |   237.998 ns |    198.739 ns |  13,080.19 ns |  25.6348 |       - |  54,792 B |
| BinaryReaderReadAbsorbance | 119,783.19 ns | 4,256.053 ns | 12,415.107 ns | 114,130.36 ns | 105.1025 | 26.2451 | 263,256 B |

As you can see the durations (BinaryReaderReadAbsorbance) have gone down. I've also made sure that all the unit tests pass following these changes as well. Could you please confirm whether or not you think my changes are valid?

Thank you!
