### PR TITLE
improve spa writer

### DIFF
--- a/src/SpaFileReader/SpaFile.cs
+++ b/src/SpaFileReader/SpaFile.cs
@@ -251,12 +251,7 @@ public static class SpaFile
     private static Span<byte> WriteByteAt(this ref Span<byte> data, short expectedFlag, Span<byte> bytesToWrite)
     {
         var (start, length) = ReadSpecificFlagPositions(ref data, expectedFlag);
-        var n = 0;
-        for (var i = start; start + length > i; i ++)
-        {
-            data[i] = bytesToWrite[n];
-            n++;
-        }
+        bytesToWrite.CopyTo(data.Slice(start, length));
         return data;
     }
 }


### PR DESCRIPTION
Instead of looping through the bytes we use the CopyTo operation which uses Buffer.memmove.

@pohldk @magnusenevoldsen